### PR TITLE
Left and Right Hand

### DIFF
--- a/VR_Piano/Assets/Scenes/SampleScene.unity
+++ b/VR_Piano/Assets/Scenes/SampleScene.unity
@@ -2011,35 +2011,38 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   songFiles:
+  - {fileID: 4900000, guid: b28f3fa00c26c6e40a235f5e313fdcfa, type: 3}
   - {fileID: 4900000, guid: 3e73b8bec89b0ac449eedeb0d3ae0f89, type: 3}
+  - {fileID: 4900000, guid: 689fb949a61898e41b2fc8bb0263dc01, type: 3}
   - {fileID: 4900000, guid: 845fbb75c20aee34c864e68384650749, type: 3}
+  - {fileID: 4900000, guid: 83bc120de07130743a58b7bfb262c4af, type: 3}
   - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
+  - {fileID: 4900000, guid: b28f3fa00c26c6e40a235f5e313fdcfa, type: 3}
   - {fileID: 4900000, guid: 3e73b8bec89b0ac449eedeb0d3ae0f89, type: 3}
+  - {fileID: 4900000, guid: 689fb949a61898e41b2fc8bb0263dc01, type: 3}
+  - {fileID: 4900000, guid: 845fbb75c20aee34c864e68384650749, type: 3}
+  - {fileID: 4900000, guid: 83bc120de07130743a58b7bfb262c4af, type: 3}
   - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  toNoteCallback: {fileID: 1920611238}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
-  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
+  - {fileID: 4900000, guid: b28f3fa00c26c6e40a235f5e313fdcfa, type: 3}
   - {fileID: 4900000, guid: 3e73b8bec89b0ac449eedeb0d3ae0f89, type: 3}
+  - {fileID: 4900000, guid: 689fb949a61898e41b2fc8bb0263dc01, type: 3}
+  - {fileID: 4900000, guid: 845fbb75c20aee34c864e68384650749, type: 3}
+  - {fileID: 4900000, guid: 83bc120de07130743a58b7bfb262c4af, type: 3}
   - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
+  - {fileID: 4900000, guid: b28f3fa00c26c6e40a235f5e313fdcfa, type: 3}
+  - {fileID: 4900000, guid: 3e73b8bec89b0ac449eedeb0d3ae0f89, type: 3}
+  - {fileID: 4900000, guid: 689fb949a61898e41b2fc8bb0263dc01, type: 3}
+  - {fileID: 4900000, guid: 845fbb75c20aee34c864e68384650749, type: 3}
+  - {fileID: 4900000, guid: 83bc120de07130743a58b7bfb262c4af, type: 3}
+  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
+  - {fileID: 4900000, guid: b28f3fa00c26c6e40a235f5e313fdcfa, type: 3}
+  - {fileID: 4900000, guid: 3e73b8bec89b0ac449eedeb0d3ae0f89, type: 3}
+  - {fileID: 4900000, guid: 689fb949a61898e41b2fc8bb0263dc01, type: 3}
+  - {fileID: 4900000, guid: 845fbb75c20aee34c864e68384650749, type: 3}
+  - {fileID: 4900000, guid: 83bc120de07130743a58b7bfb262c4af, type: 3}
+  - {fileID: 4900000, guid: 4138cc426bde37844a9c40a331661d08, type: 3}
+  - {fileID: 4900000, guid: b28f3fa00c26c6e40a235f5e313fdcfa, type: 3}
+  - {fileID: 4900000, guid: 3e73b8bec89b0ac449eedeb0d3ae0f89, type: 3}
   toNoteCallback: {fileID: 170974396}
 --- !u!4 &354958242
 Transform:
@@ -11143,17 +11146,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1917186214}
   m_CullTransparentMesh: 1
---- !u!114 &1920611238 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2302999714558474702, guid: 42d778a5865494f3987eaa1548ea5c6e, type: 3}
-  m_PrefabInstance: {fileID: 170974395}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ef80b44c05b194c4c8d2a3405558a3c2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1946448396
 GameObject:
   m_ObjectHideFlags: 0

--- a/VR_Piano/Assets/Scripts/MidiMessages.cs
+++ b/VR_Piano/Assets/Scripts/MidiMessages.cs
@@ -25,18 +25,22 @@ public class MidiMessages : MonoBehaviour
     public async void PlaySong(int songIndex)
     {
         // Checks that song index is in range
-        if (songIndex >= 1 && songIndex <= songFiles.Length)
+        if (songIndex >= 1 && songIndex * 2 <= songFiles.Length)
         {
             // Getter for TextAsset according to songIndex
-            TextAsset songTextAsset = songFiles[songIndex - 1];
+            TextAsset leftPart = songFiles[(songIndex * 2) - 2]; // Left part, even index
+            TextAsset rightPart = songFiles[(songIndex * 2) - 1]; // Right part, odd index
 
             // Checks if the files exists
-            if (songTextAsset != null)
+            if (leftPart != null && rightPart != null)
             {
-                // Waits to process the data from TextAsset first
-                await ExtractMidiData(songTextAsset);
 
-                Debug.LogError("Playing song: " + songTextAsset.name);
+                Debug.Log($"Playing song: {leftPart.name} (Left) and {rightPart.name} (Right)");
+
+                Task leftTask = ExtractMidiData(leftPart);
+                Task rightTask = ExtractMidiData(rightPart);
+
+                await Task.WhenAll(leftTask, rightTask); // waits for both tasks to finish before moving to the next step
             }
             else
             {


### PR DESCRIPTION
Both left and right hand midi files now both play at the same time for a selected play scene.

SampleScene:
- Added 32 elements (left and right pairs for 1 song) to account for the 16 songs in play scene and organized the files in Unity Editor to cycle through the 3 songs we currently have and have the corrected pairs.

MidiMessages.cs:
- Added logic to account for the 2 midi files to play at the same time that way each play scene would always have the correct left-right pairings.

I found that more sound limitations was present now that there are two midi files being used. This results in sound not playing on some notes.